### PR TITLE
Update client version record

### DIFF
--- a/resources/lib/rrmj.py
+++ b/resources/lib/rrmj.py
@@ -15,7 +15,7 @@ FAKE_HEADERS = {
     "a": "cf2ecd4d-dea3-40ca-814f-3f0462623b1c",
     "b": "",
     "clientType": "android_%E5%B0%8F%E7%B1%B3",
-    "clientVersion": "2.0.7.3",
+    "clientVersion": "99.99",
     "c": "5a1fb134-9384-4fc8-a5ae-6e711e24afc1",
     "d": "",
     "e": "d4dd075d894dd2b8c81f96062dbe7dcbf7d467fd"


### PR DESCRIPTION
rrmj has update it's client app version recently. Older version plugin failed to fetch information from api.rrmj.tv.
Update the client version to '99.99',  so that no need to concern this problem again.